### PR TITLE
Update GitHub links to gene-lang org

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,7 +30,7 @@ const year = new Date().getFullYear();
 					<a href="/tutorials" class:list={{ active: Astro.url.pathname.startsWith('/tutorials') }}>Tutorials</a>
 					<a href="/examples" class:list={{ active: Astro.url.pathname.startsWith('/examples') }}>Examples</a>
 					<a href="/community" class:list={{ active: Astro.url.pathname.startsWith('/community') }}>Community</a>
-					<a href="https://github.com/gcao/gene" rel="noopener">GitHub</a>
+                                        <a href="https://github.com/gene-lang/gene" rel="noopener">GitHub</a>
 				</nav>
 			</div>
 		</header>
@@ -44,7 +44,7 @@ const year = new Date().getFullYear();
 					<p>Open-source Lisp for building fast, expressive systems.</p>
 				</div>
 				<div class="footer-links">
-					<a href="https://github.com/gcao/gene" rel="noopener">Source</a>
+                                        <a href="https://github.com/gene-lang/gene" rel="noopener">Source</a>
 					<a href="/getting-started">Install</a>
 					<a href="/docs">Documentation</a>
 					<a href="/community">Community</a>

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -21,7 +21,7 @@ import Layout from '../layouts/Layout.astro';
 				Track development, open issues, and submit pull requests. The runtime, compiler, and website all live in the
 				public repository.
 			</p>
-			<a class="button-link" href="https://github.com/gcao/gene" rel="noopener">github.com/gcao/gene →</a>
+                        <a class="button-link" href="https://github.com/gene-lang/gene" rel="noopener">github.com/gene-lang/gene →</a>
 		</article>
 
 		<article class="card">
@@ -30,7 +30,7 @@ import Layout from '../layouts/Layout.astro';
 				Larger changes start with an OpenSpec proposal. Read existing specs, or draft a new one to propose language,
 				tooling, or documentation improvements.
 			</p>
-			<a class="button-link" href="https://github.com/gcao/gene/tree/main/openspec" rel="noopener">
+                        <a class="button-link" href="https://github.com/gene-lang/gene/tree/main/openspec" rel="noopener">
 				OpenSpec workflow →
 			</a>
 		</article>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -73,7 +73,7 @@ const sections = [
 			Found a gap? Open an issue or pull request via the OpenSpec workflow. Contributions are welcome for tutorials,
 			examples, and architecture notes.
 		</p>
-		<a class="button primary" href="https://github.com/gcao/gene" rel="noopener">Contribute on GitHub</a>
+                <a class="button primary" href="https://github.com/gene-lang/gene" rel="noopener">Contribute on GitHub</a>
 	</section>
 </Layout>
 

--- a/src/pages/getting-started.astro
+++ b/src/pages/getting-started.astro
@@ -13,7 +13,7 @@ import Layout from '../layouts/Layout.astro';
 			builds on Nim, so the same instructions work across macOS, Linux, and Windows.
 		</p>
 		<div class="quick-actions">
-			<a class="button primary" href="https://github.com/gcao/gene" rel="noopener">View source on GitHub</a>
+                        <a class="button primary" href="https://github.com/gene-lang/gene" rel="noopener">View source on GitHub</a>
 			<a class="button secondary" href="/docs">Explore documentation</a>
 		</div>
 	</section>
@@ -33,7 +33,7 @@ import Layout from '../layouts/Layout.astro';
 	<section class="step">
 		<h2>2. Clone the repository</h2>
 		<pre aria-label="Clone the Gene repository">
-<code class="language-bash">git clone https://github.com/gcao/gene.git
+<code class="language-bash">git clone https://github.com/gene-lang/gene.git
 cd gene</code>
 		</pre>
 		<p>If you are contributing, fork the repository first and add your fork as the origin remote.</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -112,7 +112,7 @@ const ecosystem = [
 			Gene is crafted in the open. Share feedback, propose specs, and help shape the language runtime, compiler,
 			and tools.
 		</p>
-		<a class="button primary" href="https://github.com/gcao/gene" rel="noopener">
+                <a class="button primary" href="https://github.com/gene-lang/gene" rel="noopener">
 			Contribute on GitHub
 		</a>
 	</section>

--- a/src/pages/tutorials/index.astro
+++ b/src/pages/tutorials/index.astro
@@ -50,7 +50,7 @@ import Layout from '../../layouts/Layout.astro';
 			We welcome community-authored walkthroughs. Share your idea through an OpenSpec proposal or open a GitHub issue
 			to coordinate.
 		</p>
-		<a class="button primary" href="https://github.com/gcao/gene/discussions" rel="noopener">Discuss a tutorial idea</a>
+                <a class="button primary" href="https://github.com/gene-lang/gene/discussions" rel="noopener">Discuss a tutorial idea</a>
 	</section>
 </Layout>
 


### PR DESCRIPTION
## Summary
- point all website GitHub links to the new gene-lang/gene repository
- update discussions and OpenSpec links to follow the new organization namespace

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_69050d4d8e308328b2e8e3b7a7b92041